### PR TITLE
Fix robots.txt sitemap URL to avoid potential double-slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,4 +18,5 @@ markdown: kramdown
 plugins:
     - jekyll-redirect-from
     - jekyll-sitemap
+    - jekyll-seo-tag
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,35 +3,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% assign page_title = page.title | default: site.title | escape %}
-  {% assign page_description = page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 %}
-  {% assign page_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
-
-  <title>{{ page_title }}</title>
-  <meta name="description" content="{{ page_description }}">
+  {% seo %}
 
   <link rel="stylesheet" href="{{ "/css/main.css" | relative_url }}">
-  <link rel="canonical" href="{{ page_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | relative_url }}">
-
-  <!-- Open Graph -->
-  <meta property="og:title" content="{{ page_title }}">
-  <meta property="og:description" content="{{ page_description }}">
-  <meta property="og:url" content="{{ page_url }}">
-  <meta property="og:site_name" content="{{ site.title }}">
-  <meta property="og:type" content="{% if page.date %}article{% else %}website{% endif %}">
-  {% if page.image %}<meta property="og:image" content="{{ page.image | prepend: site.baseurl | prepend: site.url }}">{% endif %}
-  {% if page.date %}
-  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
-  <meta property="article:author" content="{{ site.title }}">
-  {% endif %}
-
-  <!-- Twitter Card -->
-  <meta name="twitter:card" content="{% if page.image %}summary_large_image{% else %}summary{% endif %}">
-  <meta name="twitter:site" content="@srvaroa">
-  <meta name="twitter:title" content="{{ page_title }}">
-  <meta name="twitter:description" content="{{ page_description }}">
-  {% if page.image %}<meta name="twitter:image" content="{{ page.image | prepend: site.baseurl | prepend: site.url }}">{% endif %}
 
   <script defer src="https://eu.umami.is/script.js" data-website-id="bb30c536-a7c9-46f5-b50c-7239169c7561"></script>
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,11 @@
 layout: default
 ---
 <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+  <meta itemprop="description" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}">
+  <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+    <meta itemprop="name" content="{{ site.title }}">
+    <meta itemprop="url" content="{{ site.url }}">
+  </span>
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>

--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: {{ site.url | append: "/sitemap.xml" }}


### PR DESCRIPTION
The previous template concatenation could produce a malformed URL.
Use Liquid append filter to construct the URL cleanly.